### PR TITLE
Infer runtime / arch / os platform from runtime stdlib

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,11 +10,11 @@ go get -u github.com/v3io/version-go
 
 ## Usage
 
-During build Add the following linker arguments to inject the version:
+During build, add the following linker arguments to inject the version:
 
 ```sh
--ldflags="-X github.com/v3io/version/version.gitCommit=$(GIT_COMMIT) \
--X github.com/v3io/version/version.label=$(GIT_TAG)
+-ldflags="-X github.com/v3io/version-go/version.gitCommit=$(GIT_COMMIT) \
+-X github.com/v3io/version-go/version.label=$(GIT_TAG)
 ```
 
 In your application, you can then:

--- a/README.md
+++ b/README.md
@@ -1,16 +1,24 @@
-# version
-Go module to maintain an applicaiton version
+# Version
+
+Go module to maintain an application version
+
+## Install
+
+```sh
+go get -u github.com/v3io/version-go
+```
 
 ## Usage
+
 During build Add the following linker arguments to inject the version:
-```
+
+```sh
 -ldflags="-X github.com/v3io/version/version.gitCommit=$(GIT_COMMIT) \
--X github.com/v3io/version/version.label=$(GIT_TAG) \
--X github.com/v3io/version/version.os=$(GOOS) \
--X github.com/v3io/version/version.arch=$(GOARCH)"
+-X github.com/v3io/version/version.label=$(GIT_TAG)
 ```
 
 In your application, you can then:
+
 ```go
 import "github.com/v3io/version-go"
 

--- a/version.go
+++ b/version.go
@@ -2,6 +2,7 @@ package version
 
 import (
 	"fmt"
+	"runtime"
 )
 
 type Info struct {
@@ -9,6 +10,7 @@ type Info struct {
 	GitCommit string `json:"git_commit"`
 	OS        string `json:"os"`
 	Arch      string `json:"arch"`
+	GoVersion string `json:"go_version"`
 }
 
 // these global variables are initialized by the build process if the build target
@@ -16,8 +18,9 @@ type Info struct {
 var (
 	label     = "latest"
 	gitCommit = ""
-	os        = ""
-	arch      = ""
+	os        = runtime.GOOS
+	arch      = runtime.GOARCH
+	goVersion = runtime.Version()
 )
 
 // Get returns the version information
@@ -29,6 +32,7 @@ func Get() *Info {
 		GitCommit: gitCommit,
 		OS:        os,
 		Arch:      arch,
+		GoVersion: goVersion,
 	}
 }
 
@@ -38,13 +42,15 @@ func Set(info *Info) {
 	gitCommit = info.GitCommit
 	os = info.OS
 	arch = info.Arch
+	goVersion = info.GoVersion
 }
 
 // String will print out the info
 func (s *Info) String() string {
-	return fmt.Sprintf("Label: %s, Git commit: %s, OS: %s, Arch: %s",
+	return fmt.Sprintf("Label: %s, Git commit: %s, OS: %s, Arch: %s, Go version: %s",
 		s.Label,
 		s.GitCommit,
 		s.OS,
-		s.Arch)
+		s.Arch,
+		s.GoVersion)
 }


### PR DESCRIPTION
- Allow to minimize the flags needs to be injected
- Correctes when building inside docker container (should not infer from host)
- Added GoVersion 
